### PR TITLE
chore: limit Dependabot to hub only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Dependabot only runs for directories listed below. Omit experiments/ to avoid
+# noise on legacy sketches. Add "/experiments2/..." entries if you want updates there.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/hub"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/hub-ci.yml
+++ b/.github/workflows/hub-ci.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - "hub/**"
       - ".github/workflows/hub-ci.yml"
+      - ".github/dependabot.yml"
   push:
     paths:
       - "hub/**"
       - ".github/workflows/hub-ci.yml"
+      - ".github/dependabot.yml"
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` so **Dependabot version updates** only run for **`/hub`** (npm). Legacy **`experiments/*`** trees are not registered, which stops the flood of PRs/workflows for old sketch `package.json` files.

## Notes
- **Dependabot security alerts** can still flag vulnerabilities in the repo; this file only scopes **version update** PRs.
- To receive updates for `experiments2` later, add additional `package-ecosystem: npm` entries with the right `directory` paths.

## Test plan
- [ ] Merge and confirm Dependabot no longer opens updates under `experiments/` (may take until the next scheduled run).

Made with [Cursor](https://cursor.com)