### PR TITLE
fix(webgpu_particles): set GitHub Pages base only at build

### DIFF
--- a/experiments/webgpu_particles/vite.config.js
+++ b/experiments/webgpu_particles/vite.config.js
@@ -1,15 +1,18 @@
 import { defineConfig } from 'vite';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 
-export default defineConfig({
-  plugins: [
-    basicSsl()
-  ],
+// Only apply the GitHub Pages subpath at build time so local dev stays at "/".
+export default defineConfig(({ command }) => ({
+  base:
+    command === 'build'
+      ? '/Sketches/experiments/webgpu_particles/dist/'
+      : '/',
+  plugins: [basicSsl()],
   server: {
     // Port is set by scripts/dev.mjs to find next available (works around
     // Vite port detection issues with host: true + HTTPS)
     strictPort: true, // We pre-resolve the port, so require it
     https: true,
     host: true, // This allows network access alongside HTTPS
-  }
-});
+  },
+}));


### PR DESCRIPTION
Use Vite's conditional config so `base` is the GitHub Pages subpath (/Sketches/experiments/webgpu_particles/dist/) only during `vite build`, keeping local dev served from `/` for short URLs.

Fixes blank deployed page caused by absolute asset paths resolving to the wrong location on yiwenl.github.io.